### PR TITLE
Add an example of using a raw SQLAlchemy query

### DIFF
--- a/stacks/census/censusv2service.py
+++ b/stacks/census/censusv2service.py
@@ -6,7 +6,8 @@ from dataservices.recipe import *
 from dataservices.redshift_connectionbase import *
 from dataservices.servicebase import *
 from dataservices.recipe_pool import RecipePool
-from dataservices.renderers import OptionChooserRenderer, RenderableQuery
+from dataservices.renderers import OptionChooserRenderer
+from dataservices.renderable_query import RenderableQuery
 from dataservices.servicebasev3 import RecipeServiceBaseV3
 
 # -------------

--- a/stacks/census/censusv2service.py
+++ b/stacks/census/censusv2service.py
@@ -1,12 +1,12 @@
 import time
-from sqlalchemy import Column, String, ForeignKey, select, join
+from sqlalchemy import Column, String, ForeignKey, select, join, func, case
 
 from dataservices.mixins import DownloadTable
 from dataservices.recipe import *
 from dataservices.redshift_connectionbase import *
 from dataservices.servicebase import *
 from dataservices.recipe_pool import RecipePool
-from dataservices.renderers import OptionChooserRenderer
+from dataservices.renderers import OptionChooserRenderer, RenderableQuery
 from dataservices.servicebasev3 import RecipeServiceBaseV3
 
 # -------------
@@ -268,24 +268,59 @@ class LeaderboardV3Service(CensusService):
         self.response['responses'] = results
         print 'Ms: ', current_milli_time() - start
 
-
 class RankedListV3Service(CensusService):
-    def build_response(self):
-        start = current_milli_time()
-        self.metrics = ('avgage', 'pop2008')
-        self.dimensions = ('state', )
-        recipe1 = self.recipe().metrics(*self.metrics).dimensions(
-            *self.dimensions).order_by('avgage')
-        self.dimensions = ('sex',)
-        recipe2 = self.recipe().metrics(*self.metrics).dimensions(
-            *self.dimensions).order_by('avgage')
-        results = RecipePool([
-            (recipe1, 'States'), (recipe2, 'Gender'),
-        ]).run()
-        self.response['responses'] = results
-        print 'Ms: ',current_milli_time() - start
+    def build_recipe(self):
+        recipe1 = self.recipe().metrics('avgage', 'pop2008').dimensions('state').order_by('avgage')
+        recipe2 = self.recipe().metrics('avgage', 'pop2008').dimensions('sex').order_by('avgage')
+        return [recipe1.prepare(name='States'), recipe2.prepare(name='Gender')]
 
+class RankedListRawQuery(CensusService):
+    """An example of how to use raw SQLAlchemy queries instead of the Recipe library.
+    This should be identical to :class:`RankedListV3Service`.
+    """
 
+    def build_recipe(self):
+        avgage_clause = func.sum(Census.pop2008 * Census.age) / func.sum(Census.pop2008)
+        filters = and_(
+            Census.sex.in_(self.automatic_filters['sex']),
+            Census.state.in_(self.automatic_filters['state']))
+        state_query = (
+            select([
+                Census.state.label('state_id'), Census.state,
+                avgage_clause.label('avgage'),
+                func.sum(Census.pop2008).label('pop2008')
+            ])
+            .where(filters)
+            .group_by(Census.state)
+            .order_by(avgage_clause)
+        )
+
+        gender_query = (
+            select([
+                Census.sex.label('sex_id'),
+                case({'F': 'Womenfolk', 'M': 'Menfolk'}, value=Census.sex).label('sex'),
+                avgage_clause.label('avgage'),
+                func.sum(Census.pop2008).label('pop2008')
+            ])
+            .where(filters)
+            .group_by(Census.sex)
+            .order_by(avgage_clause)
+        )
+
+        metadata = {
+            'avgage': {'format': '.1f'},
+            'pop2008': {'format': '.3s'},
+        }
+
+        state = RenderableQuery(
+            service=self, query=state_query,
+            name='State', dimensions=['state'], metrics=['avgage', 'pop2008'],
+            metadata=metadata)
+        gender = RenderableQuery(
+            service=self, query=gender_query,
+            name='Gender', dimensions=['sex'], metrics=['avgage', 'pop2008'],
+            metadata=metadata)
+        return [state, gender]
 
 class LollipopV3Service(CensusService):
     def build_response(self):

--- a/stacks/census/stack.yaml
+++ b/stacks/census/stack.yaml
@@ -138,7 +138,15 @@ slices:
   style:
     - "section-content"
   data_service: "censusv2service.RankedListV3Service"
-  extra_css: ""
+
+- slug: "ranked_list_raw_query"
+  slice_type: "ranked-list"
+  title: "ranked-list (raw query)"
+  config:
+    "disableSort": true
+  style:
+    - "section-content"
+  data_service: "censusv2service.RankedListRawQuery"
 
 - slice_type: "ranked-list-2"
   slug: "rl2"


### PR DESCRIPTION
Ticket: [JB-1956](https://juiceanalytics.atlassian.net/browse/JB-1956)
Type: Feature

# Changes
- add a `ranked_list_raw_query` slice with type `ranked-list`
- implement the dataservice for it by using raw SQLAlchemy queries. it is identical to the existing `COOKIES` slice.
- also ported the ranked-list `COOKIES` slice to use `build_recipe` instead of `build_response`.


The JB branch implementing this feature is still outstanding: https://github.com/juiceinc/fruition/pull/1279