### PR TITLE
switch from `build_recipe` to `build_renderers`

### DIFF
--- a/stacks/census/censusv2service.py
+++ b/stacks/census/censusv2service.py
@@ -273,7 +273,7 @@ class RankedListV3Service(CensusService):
     def build_renderers(self):
         recipe1 = self.recipe().metrics('avgage', 'pop2008').dimensions('state').order_by('avgage')
         recipe2 = self.recipe().metrics('avgage', 'pop2008').dimensions('sex').order_by('avgage')
-        return [recipe1.prepare(name='States'), recipe2.prepare(name='Gender')]
+        return [self.renderer('States', data=recipe1), self.renderer('Gender', data=recipe2)]
 
 class RankedListRawQuery(CensusService):
     """An example of how to use raw SQLAlchemy queries instead of the Recipe library.

--- a/stacks/census/censusv2service.py
+++ b/stacks/census/censusv2service.py
@@ -270,7 +270,7 @@ class LeaderboardV3Service(CensusService):
         print 'Ms: ', current_milli_time() - start
 
 class RankedListV3Service(CensusService):
-    def build_recipe(self):
+    def build_renderers(self):
         recipe1 = self.recipe().metrics('avgage', 'pop2008').dimensions('state').order_by('avgage')
         recipe2 = self.recipe().metrics('avgage', 'pop2008').dimensions('sex').order_by('avgage')
         return [recipe1.prepare(name='States'), recipe2.prepare(name='Gender')]
@@ -280,7 +280,7 @@ class RankedListRawQuery(CensusService):
     This should be identical to :class:`RankedListV3Service`.
     """
 
-    def build_recipe(self):
+    def build_renderers(self):
         avgage_clause = func.sum(Census.pop2008 * Census.age) / func.sum(Census.pop2008)
         filters = []
         if 'state' in self.automatic_filters:


### PR DESCRIPTION
Type: Fix

## Changes

The `build_recipe` method has been removed and replaced with `build_renderers`. This method CAN continue to return "prepared recipes" (as they are "renderable"), but I also decided to change the one implementation that was previously returning "prepared recipes" to instead return Renderer objects, using the new `self.renderer` method on data services.